### PR TITLE
Add ginkgo to ubuntu 2204 ci image

### DIFF
--- a/ci-ubuntu-2204.dockerfile
+++ b/ci-ubuntu-2204.dockerfile
@@ -32,4 +32,7 @@ RUN apt-get -qq update && \
         wget \
     && rm -rf /var/lib/apt/lists/*
 
+COPY --chown=root:root ginkgo/99-ginkgo-env.sh /etc/profile.d/
+COPY ginkgo/ginkgo-install.sh ginkgo-install.sh
+RUN ./ginkgo-install.sh && rm ginkgo-install.sh
 CMD ["/bin/bash", "--login"]

--- a/ginkgo/99-ginkgo-env.sh
+++ b/ginkgo/99-ginkgo-env.sh
@@ -1,0 +1,4 @@
+# Copy this file into /etc/profile.d/
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Ginkgo_DIR/lib
+export CPATH=$CPATH:$Ginkgo_DIR/include

--- a/ginkgo/99-ginkgo-install.sh
+++ b/ginkgo/99-ginkgo-install.sh
@@ -1,4 +1,0 @@
-# Copy this file into /etc/profile.d/
-
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Ginkgo_DIR/lib
-export CPATH=$CPATH:$Ginkgo_DIR/include

--- a/ginkgo/99-ginkgo-install.sh
+++ b/ginkgo/99-ginkgo-install.sh
@@ -1,0 +1,4 @@
+# Copy this file into /etc/profile.d/
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Ginkgo_DIR/lib
+export CPATH=$CPATH:$Ginkgo_DIR/include

--- a/ginkgo/ginkgo-install.sh
+++ b/ginkgo/ginkgo-install.sh
@@ -1,0 +1,9 @@
+# This script installs GINKGO
+VERSION=3.12.4
+
+export Ginkgo_DIR=$(pwd)/ginkgo/build
+
+wget -c https://github.com/ginkgo-project/ginkgo/archive/refs/heads/public_common_kernels.zip
+unzip public_common_kernels.zip && mv ginkgo-public_common_kernels ginkgo
+cd ginkgo && mkdir build && cd build
+cmake .. && make


### PR DESCRIPTION
... in order to test at least the reference (and potentially the OpenMP) executor.

Note that I try to install ginkgo in the build directory on purpose, as the shortcoming of the CMake handling here needs access to the CMake modules of ginkgo itself.